### PR TITLE
Support for different LLM hosts (remote or local, compatible with OpenAI API interface)

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,15 @@ vibesafe scan -r
 vibesafe scan --report 
 ```
 
-**Generate AI Report (Requires API Key):**
+*Using a local llm host for report (the llm host must support OpenAI API)
+```bash
+ # example with ollama at local host with default ollama port
+ vibesafe scan --url http://127.0.0.1:11434 --model gemma3:27b-it-q8_0
+```
+
+if --url flag is not specified the report will be done by OpenAI (you will need an OpenAI API Key, see below)
+
+**Generate AI Report from OpenAI (Requires API Key):**
 
 To generate fix suggestions in the Markdown report, you need an OpenAI API key.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,8 @@ program.command('scan')
   .option('-o, --output <file>', 'Specify JSON output file path (e.g., report.json)')
   .option('-r, --report [file]', 'Specify Markdown report file path (defaults to VIBESAFE-REPORT.md)')
   .option('--high-only', 'Only report high severity issues')
+  .option('-m, --model <model>', 'Specify OpenAI model to use for suggestions. If not specified the program will use gpt-4.1-nano', 'gpt-4.1-nano')
+  .option('-u, --url <url>', 'Use the specified url (e.g. http://localhost:11434 for ollama or https://api.openai.com for ChatGPT) for ai suggestions. If not specified the program will call OpenAI API', 'https://api.openai.com')
   .action(async (directory, options) => {
     const rootDir = path.resolve(directory);
     console.log(`Scanning directory: ${rootDir}`);
@@ -310,7 +312,7 @@ program.command('scan')
             infoSecretFindings: infoSecretFindings
         };
         try {
-            const markdownContent = await generateMarkdownReport(reportData);
+            const markdownContent = await generateMarkdownReport(reportData, options.url, options.model);
             fs.writeFileSync(reportPath, markdownContent);
             console.log(chalk.green(`\nMarkdown report generated successfully at ${reportPath}`));
         } catch (error: any) {

--- a/src/reporting/aiSuggestions.ts
+++ b/src/reporting/aiSuggestions.ts
@@ -51,11 +51,12 @@ const MAX_FINDINGS_PER_TYPE = 10;
 /**
  * Generates AI-powered suggestions for fixing findings.
  * @param reportData The aggregated findings.
- * @param apiKey OpenAI API key.
+ * @param openaiConf OpenAI API key and url.
+ * @param model model name.
  * @returns A promise resolving to a Markdown string with suggestions.
  */
-export async function generateAISuggestions(reportData: ReportData, apiKey: string): Promise<string> {
-    const openai = new OpenAI({ apiKey });
+export async function generateAISuggestions(reportData: ReportData, openaiConf: {baseURL:string, apiKey: string}, model: string): Promise<string> {
+    const openai = new OpenAI(openaiConf);
 
     // Prepare a simplified list of findings for the prompt
     const simplifiedFindings: SimplifiedFinding[] = [
@@ -92,7 +93,7 @@ export async function generateAISuggestions(reportData: ReportData, apiKey: stri
 
     try {
         const completion = await openai.chat.completions.create({
-            model: "gpt-4.1-nano",
+            model: model,
             messages: [
                 { role: "system", content: "You are a helpful security assistant providing fix suggestions for code vulnerabilities." },
                 { role: "user", content: prompt }


### PR DESCRIPTION
added two flags for the scan command:
* __--url <llm_host_url>__ / __-u <llm_host_url>__  gives you the possibility to specify the url of the LLM backend (if not specified the program will use OpenAI url: https://api.openai.com)
* __--model <model_name>__ / __-m <model_name>__ gives you the possibility to choose the model you prefer (if not specified the program will use gpt-4.1-nano)

### Example:
```bash
 # example with ollama at local host with default ollama port
 vibesafe scan --url http://127.0.0.1:11434 --model gemma3:27b-it-q8_0
# or
 vibesafe scan -u http://127.0.0.1:11434 -m gemma3:27b-it-q8_0 

# or if you prefer Deepseek
vibesafe scan -u https://api.deepseek.com -m deepseek-chat
```