### PR TITLE
fix the build pipeline failure

### DIFF
--- a/.vibesafeignore
+++ b/.vibesafeignore
@@ -1,2 +1,2 @@
-# Ignore specific test files for self-scan
-test-data/config.js 
+# Ignore test directory for self-scan (tests can be unsafe)
+test-data/

--- a/README.md
+++ b/README.md
@@ -111,9 +111,9 @@ To generate fix suggestions in the Markdown report, you need an OpenAI API key.
     OPENAI_API_KEY=sk-YourActualOpenAIKeyHere
     ```
 3.  Run the scan with the report flag:
-    ```bash
+```bash
 vibesafe scan -r ai-report.md
-    ```
+```
 
 **Show Only High/Critical Issues:**
 


### PR DESCRIPTION
Fixed #5 

## Problem
The build pipeline after PR merge fails because vibesafe scan itself to find if it has some security issues and it finds them in the `test-data` directory, because we have there some tests with unsafe code that vibesafe correctly find.
## The Solution
Adding `test-data` to the `.vibesafeignore` file
#

Also a formatting error in the README.md was remove